### PR TITLE
Bug fix for padded scale loads in fp8xmxfp4 mode; ensure TMA load

### DIFF
--- a/bench/triton_bench/matmul_ogs_details/_p_matmul_ogs.py
+++ b/bench/triton_bench/matmul_ogs_details/_p_matmul_ogs.py
@@ -328,7 +328,6 @@ def _p_matmul_ogs(
         acc = tl.zeros((BLOCK_N, BLOCK_M) if SWAP_XW else (BLOCK_M, BLOCK_N), dtype=tl.float32)
         for ki in tl.range(k_tiles, disallow_acc_multi_buffer=DISALLOW_ACC_MULTI_BUFFER):
             off_k = pid_k * BLOCK_K + ki * BLOCK_K * SPLIT_K
-            off_k_w = pid_k * PACKED_BLOCK_K_W + ki * PACKED_BLOCK_K_W * SPLIT_K
             off_k_mx = pid_k * MX_SCALE_BLOCK_K + ki * MX_SCALE_BLOCK_K * SPLIT_K
 
             if USE_GATHER_TMA:
@@ -347,7 +346,11 @@ def _p_matmul_ogs(
                     mask_k = tl.arange(0, BLOCK_K) < K - off_k
                     x = tl.load(XPtrs, mask=mask_k[None, :], other=0.0)
 
-            w = _load_tensor_desc(w_desc, [expt_id, off_k_w, off_n], transpose=W_TRANSPOSE)
+            # Note: use off_k here which spans BLOCK_K elements and _not_ PACKED_BLOCK_K_W bytes.
+            # When using the unpacked destination dtype, the fp4 elements are unpacked into a padded
+            # layout, b4x16_p64. In this case, the TMA requires the contiguous dimension be a multiple
+            # of 128 elements.
+            w = _load_tensor_desc(w_desc, [expt_id, off_k, off_n], transpose=W_TRANSPOSE)
 
             if is_microscaled_format:
                 x_format: tl.constexpr = get_scaled_dot_format_string(x.dtype)

--- a/test/Conversion/invalid.mlir
+++ b/test/Conversion/invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: not triton-opt %s --convert-triton-gpu-to-llvm 2>&1 | FileCheck %s
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+tt.func @padded_fp4_tma_misaligned_load(%ptr : !tt.ptr<i8>, %bar : !ttg.memdesc<1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable>) {
+  %dst  = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1x128xi8, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8, fp4Padded = true}>, #ttg.shared_memory, mutable>
+  %c0   = arith.constant 0   : i32
+  %c64  = arith.constant 64  : i32
+  %pred = arith.constant true
+  // CHECK: Illegal fp4 padded tensor coordinate; contiguous coordinate (64) is not a multiple of 128
+  ttng.async_tma_copy_global_to_local %ptr[%c0, %c64] %dst, %bar, %pred : !tt.ptr<i8>, !ttg.memdesc<1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable> -> !ttg.memdesc<1x128xi8, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8, fp4Padded = true}>, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+}


### PR DESCRIPTION
<git-pr-chain>


Bug fix for padded scale loads in fp8xmxfp4 mode; ensure TMA load
requirements are met when using the unpacked fp4 (padded) layout.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #1
1. #2
1. 👉 #3 👈 **YOU ARE HERE**

⚠️⚠️ Please **do not click the green "merge" button** unless you know what
you're doing.  This PR is part of a chain of PRs, and clicking the merge
button will not merge it into master. ⚠️⚠️ 
</git-pr-chain>
